### PR TITLE
[Fix] Standardize Dev Ports (#8)

### DIFF
--- a/dashboard/vite.config.js
+++ b/dashboard/vite.config.js
@@ -5,7 +5,7 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 4004,
+    port: 4124,
     host: true,
     watch: {
         usePolling: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
       - /app/node_modules
       - ./:/repo
     ports:
-      - "4000:4000"
+      - "4123:4123"
     depends_on:
       db:
         condition: service_healthy
@@ -105,18 +105,17 @@ services:
       - INSTAGRAM_PASSWORD=${INSTAGRAM_PASSWORD}
       - GIT_REPO_PATH=/repo
 
-
   dashboard:
     build: ./dashboard
     container_name: hotmart_dashboard
     restart: always
     ports:
-      - "4004:4004"
+      - "4124:4124"
     volumes:
       - ./dashboard:/app
       - /app/node_modules
     environment:
-      - VITE_API_URL=http://localhost:4000
+      - VITE_API_URL=http://localhost:4123
     depends_on:
       - motor
     networks:

--- a/motor/.env.example
+++ b/motor/.env.example
@@ -1,0 +1,13 @@
+PORT=4123
+REDIS_HOST=localhost
+DB_USER=hotmart_user
+DB_HOST=localhost
+DB_NAME=hotmart
+DB_PASSWORD=securepassword
+NODE_ENV=development
+
+# Credentials
+HOTMART_EMAIL=
+HOTMART_PASSWORD=
+INSTAGRAM_USER=
+INSTAGRAM_PASSWORD=


### PR DESCRIPTION
## 📝 Descripción
Sincronización de los puertos de comunicación con el estándar definido en `documents/PORTS.md`.
- Dashboard: 4124
- Motor (Backend): 4123
- Se actualizó `docker-compose.yml` base para usar estos puertos por defecto.
- Se añadió `motor/.env.example` con la configuración sugerida.

## 🔗 Issue Relacionado
Closes #8

## ✅ Checklist de Calidad
- [x] Los puertos coinciden con la documentación oficial.
